### PR TITLE
ENG-89229 fix (Icons): Roster | region icon has changed from white to…

### DIFF
--- a/style.css
+++ b/style.css
@@ -95,7 +95,6 @@
 }
 .icon-mw-roster-region:before {
   content: "\e911";
-  color: #000;
 }
 .icon-mw-roster-state:before {
   content: "\e915";


### PR DESCRIPTION
… black

                                    ____                Where's
 Good job ruining your            __\==/__            Warez Dude?
element of surprise -and-          |    |                   `,,,
  telling us where   `~--         /     \   ,     OO         '..
 you're from, idiot.  .>>.    __.'       `-'|    .||.        .||.
               _______ || ____ \           / ____ dd ________ ||